### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,5 @@
-/*
-Created by RobotCing Team
-*/
+# Created by RobotCing Team
+
 ###########################################
 # Syntax Coloring Map For Attiny84_IO_basic
 ###########################################
@@ -8,17 +7,17 @@ Created by RobotCing Team
 ###########################################
 # Datatypes (KEYWORD1)
 ###########################################
-Attiny84_IO_basic	                 KEYWORD1
+Attiny84_IO_basic	KEYWORD1
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
-Cing                               KEYWORD2
-RunMotor	                         KEYWORD2
-ReadLightSensor	                   KEYWORD2
-ReadUltrasonicSensor	             KEYWORD2
-ReadShineSensor	                   KEYWORD2
-ReadButtonExternal	               KEYWORD2
-ReadPotentiometerExternal	         KEYWORD2
+Cing	KEYWORD2
+RunMotor	KEYWORD2
+ReadLightSensor	KEYWORD2
+ReadUltrasonicSensor	KEYWORD2
+ReadShineSensor	KEYWORD2
+ReadButtonExternal	KEYWORD2
+ReadPotentiometerExternal	KEYWORD2
 
 ###########################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords